### PR TITLE
Editable paths

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -21,6 +21,7 @@ class Extension extends \Bolt\BaseExtension
     private $dev = false;
 
     private $authorized = false;
+    private $authorizedForPaths = false;
     private $backupDir;
     private $translationDir;
     private $configDirectory;
@@ -67,6 +68,20 @@ class Extension extends \Bolt\BaseExtension
             if ($this->app['users']->hasRole($currentUserId, $role)) {
                 $this->authorized = true;
                 break;
+            }
+        }
+
+        // check if user can edit paths of menu items
+        if ($this->config['pathsEditable']) {
+            if (is_array($this->config['pathsEditable'])) {
+                foreach ($this->config['pathsEditable'] as $role) {
+                    if ($this->app['users']->hasRole($currentUserId, $role)) {
+                        $this->authorizedForPaths = true;
+                        break;
+                    }
+                }
+            } else {
+                $this->authorizedForPaths = true;
             }
         }
 
@@ -310,6 +325,7 @@ class Extension extends \Bolt\BaseExtension
             'contenttypes'  => $contenttypes,
             'taxonomys'     => $taxonomys,
             'menus'         => $menus,
+            'pathsEditable' => $this->authorizedForPaths,
             'writeLock'     => $writeLock,
             'backups'       => $backups,
             'readme'        => $this->getLocalizedReadme()

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -3,6 +3,9 @@
 # available roles (by default): root, admin, developer, chief-editor, editor, guest, everyone
 permissions: [ admin, developer, chief-editor ]
 
+# either true, false or a list of roles that are allowed to edit the path of each menu item
+pathsEditable: false
+
 # creates a backup of your old menu.yml before saving
 # if you want to use this feature, make sure that the extension folder extensions/MenuEditor/backups is writable by your webserver
 enableBackups: true

--- a/views/_menuitem.twig
+++ b/views/_menuitem.twig
@@ -14,7 +14,7 @@
         {% if item.link is not defined %}
             <div class="left-inner-addon">
                 <i class="fa fa-bolt"></i>
-                <input class="me-input form-control" type="text" value="{{ item.path }}" disabled="disabled" style="width: 80%;">
+                <input class="me-input form-control" type="text" value="{{ item.path }}" {% if pathsEditable %}data-tag="path"{% else %}disabled="disabled"{% endif %} style="width: 80%;">
             </div>
         {% endif %}
         <div class="left-inner-addon">


### PR DESCRIPTION
Until now, menu item paths have not been editable. I can see this is to prevent broken links.

However, this prevents me from drafting and iterating on menus before creating the actual records or updating menu items when slugs change.

I have a use case where I have drafted an extensive menu structure in yaml and handed it over to editors, who then are working on improving it iteratively and creating the records. They need to be able to try out different menu structures and various page names easily, so I would like them to be able to edit the menu item paths instead of having to remove and recreate the items each time they make a minor edit with the record's slug.

In the configuration, it's now possible to set `pathsEditable` to true or to a list of user roles that this feature is enabled for.

I would also consider changing the default configuration **from**

```yaml
permissions: [ admin, developer, chief-editor ]
pathsEditable: false
```

**to**

```yaml
permissions: [ editor, admin, developer, chief-editor ]
pathsEditable: [ admin, developer, chief-editor ]
```

...but I'll leave that up to you, there's other things to consider as well and I don't know the ideas behind the default permission scheme super well.