### PR TITLE
Fix for searching through all contenttypes

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -256,8 +256,12 @@ class Extension extends \Bolt\BaseExtension
                     if (empty($ct)) {
                         $contenttypes = $this->app['config']->get('contenttypes');
                         foreach ($contenttypes as $ck => $contenttype) {
-                            $retVal[] = $this->app['storage']->getContent($contenttype['name'], array('title'=> "%$q%", 'limit'=>100, 'order'=>'title'));
-                            $retVal[] = $this->app['storage']->getContent($contenttype['name'], array('slug'=> "%$q%", 'limit'=>100, 'order'=>'slug'));
+                            if (isset($contenttype['fields']['title'])) {
+                                $retVal[] = $this->app['storage']->getContent($contenttype['name'], array('title'=> "%$q%", 'limit'=>100, 'order'=>'title'));
+                            }
+                            if (isset($contenttype['fields']['slug'])) {
+                                $retVal[] = $this->app['storage']->getContent($contenttype['name'], array('slug'=> "%$q%", 'limit'=>100, 'order'=>'slug'));
+                            }
                         }
                     } else {
                         $retVal[] = $this->app['storage']->getContent($ct, array('title'=> "%$q%", 'limit'=>100, 'order'=>'title'));


### PR DESCRIPTION
If people have contenttypes without title and/or slug fields, you currently can't search through all contenttypes.
These contenttypes are getting more common because it's possible to have viewless contenttypes now.
I use a contenttype to save emailadresses and I didn't made the connection between that and this problem.

This won't fix searching through a contenttype which doesn't have those fields, but nobody wants to link them to the menu anyway.