### PR TITLE
Add clearAssets and up the version requirement to 2.2.10

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -135,6 +135,11 @@ class Extension extends \Bolt\BaseExtension
         }
 
         /**
+         * Make sure that no other extensions are interfering with the menueditor JS.
+         */
+        $this->clearAssets();
+
+        /**
          * check if menu.yml is writable
          */
         $file = $this->configDirectory . '/menu.yml';

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "bolt-extension",
     "keywords": ["visual", "menu", "editor", "admin", "tool"],
     "require": {
-        "bolt/bolt": ">=2.0.0,<3.0.0"
+        "bolt/bolt": ">=2.2.10,<3.0.0"
     },
     "authors": [
         {


### PR DESCRIPTION
When another extension uses certain JS libraries on the backend it can mess with the menueditors requirejs, so I we need to clear the assets on the menueditor route. Since clearAssets wasn't added until #4031 it needs the version requirement to be upped to 2.2.10