### PR TITLE
Translation string added for select field label

### DIFF
--- a/templates/menufields.twig
+++ b/templates/menufields.twig
@@ -90,7 +90,7 @@
             <div class="input-group">
             {% endif %}
                 <select name="{{ key }}" class="form-control">
-                    <option value="none">Selecteer</option>
+                    <option value="none">{{ __('general.phrase.select') }}</option>
                     {% for name, label in values %}
                         <option value="{{ name }}" {{ value == name ? 'selected="selected"' : '' }}>{{ label }}</option>
                     {% endfor %}


### PR DESCRIPTION
The text "Selecteer" is currently hardcoded into the select field and does not use the translation methods of bolt. I changed that to use the defaults of bolt.
I dont think we need a special entry in the extensions own translation files?

Tnx for the extension ;)