### PR TITLE
[WIP] IE11 Fix

### DIFF
--- a/templates/menuitem.twig
+++ b/templates/menuitem.twig
@@ -1,7 +1,7 @@
 
 {% macro menuitem(menuitem, id, menu_config, name) %}
 {% import "@bolt/menufields.twig" as fields %}
-    <li class="mjs-nestedSortable-expanded"{% for key, value in menu_config.fields|merge(menuitem) if key not in ['submenu'] %}data-{{key}}="{{value}}"{% endfor %} id="menuitem-{{ id ~ name }}">
+    <li class="mjs-nestedSortable-expanded"{% for key, value in menu_config.fields|merge(menuitem) if key not in ['submenu'] %} data-{{key}}="{{value}}"{% endfor %} id="menuitem-{{ id ~ name }}">
         <div>
             <!-- The menuitem header -->
             <div class="flex-row">

--- a/web/menueditor.js
+++ b/web/menueditor.js
@@ -171,7 +171,6 @@ $().ready(function(){
                 newOption: true
             }
         },
-        multiple: true,
         maximumSelectionLength: 1,
         tags: true,
         escapeMarkup: function(markup) { return markup; },


### PR DESCRIPTION
~Insofar: This doesn't seem to break anything.~

When `multiple: true` is gone, it gives errors when trying to add a second element